### PR TITLE
タスク#10-商品購入機能

### DIFF
--- a/ER.dio
+++ b/ER.dio
@@ -16,13 +16,13 @@
                 <mxCell id="32" value="-name&#10;-description&#10;-price&#10;&#10;-user_id (FK)&#10;&#10;-image (ActiveStorage)&#10;&#10;-category_id (ActiveHash)&#10;-condition_id (ActiveHash)&#10;&#10;-ship_fee_id (ActiveHash)&#10;-ship_day_id (ActiveHash)&#10;-prefecture_id (ActiveHash)" style="align=left;strokeColor=none;fillColor=none;spacingLeft=4;fontSize=12;verticalAlign=top;resizable=0;rotatable=0;part=1;" vertex="1" parent="31">
                     <mxGeometry y="30" width="160" height="220" as="geometry"/>
                 </mxCell>
-                <mxCell id="33" value="orders" style="swimlane;childLayout=stackLayout;horizontal=1;startSize=30;horizontalStack=0;rounded=1;fontSize=14;fontStyle=0;strokeWidth=2;resizeParent=0;resizeLast=1;shadow=0;dashed=0;align=center;" vertex="1" parent="1">
+                <mxCell id="33" value="addresses" style="swimlane;childLayout=stackLayout;horizontal=1;startSize=30;horizontalStack=0;rounded=1;fontSize=14;fontStyle=0;strokeWidth=2;resizeParent=0;resizeLast=1;shadow=0;dashed=0;align=center;" vertex="1" parent="1">
                     <mxGeometry x="440" y="360" width="160" height="230" as="geometry"/>
                 </mxCell>
                 <mxCell id="34" value="-post_code&#10;-city&#10;-address&#10;-building&#10;-phone_num&#10;&#10;-purchase_id (FK)&#10;&#10;-prefecture_id (ActiveHash)&#10;&#10;-card_num_token (PAY.JP)&#10;-expiry_token (PAY.JP)&#10;-cvc_token (PAY.JP)" style="align=left;strokeColor=none;fillColor=none;spacingLeft=4;fontSize=12;verticalAlign=top;resizable=0;rotatable=0;part=1;" vertex="1" parent="33">
                     <mxGeometry y="30" width="160" height="200" as="geometry"/>
                 </mxCell>
-                <mxCell id="41" value="purchases" style="swimlane;childLayout=stackLayout;horizontal=1;startSize=30;horizontalStack=0;rounded=1;fontSize=14;fontStyle=0;strokeWidth=2;resizeParent=0;resizeLast=1;shadow=0;dashed=0;align=center;" vertex="1" parent="1">
+                <mxCell id="41" value="orders" style="swimlane;childLayout=stackLayout;horizontal=1;startSize=30;horizontalStack=0;rounded=1;fontSize=14;fontStyle=0;strokeWidth=2;resizeParent=0;resizeLast=1;shadow=0;dashed=0;align=center;" vertex="1" parent="1">
                     <mxGeometry x="240" y="280" width="160" height="80" as="geometry"/>
                 </mxCell>
                 <mxCell id="42" value="-user_id (FK)&#10;-item_id (FK)&#10;" style="align=left;strokeColor=none;fillColor=none;spacingLeft=4;fontSize=12;verticalAlign=top;resizable=0;rotatable=0;part=1;" vertex="1" parent="41">

--- a/Gemfile
+++ b/Gemfile
@@ -70,3 +70,5 @@ gem 'mini_magick'
 gem 'image_processing', '~> 1.2'
 
 gem 'active_hash'
+
+gem 'payjp'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -88,6 +88,8 @@ GEM
       responders
       warden (~> 1.2.3)
     diff-lcs (1.5.0)
+    domain_name (0.5.20190701)
+      unf (>= 0.0.5, < 1.0.0)
     erubi (1.12.0)
     factory_bot (6.2.1)
       activesupport (>= 5.0.0)
@@ -99,6 +101,9 @@ GEM
     ffi (1.15.5)
     globalid (1.1.0)
       activesupport (>= 5.0)
+    http-accept (1.7.0)
+    http-cookie (1.0.5)
+      domain_name (~> 0.5)
     i18n (1.12.0)
       concurrent-ruby (~> 1.0)
     image_processing (1.12.2)
@@ -123,6 +128,9 @@ GEM
     marcel (1.0.2)
     matrix (0.4.2)
     method_source (1.0.0)
+    mime-types (3.4.1)
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2023.0218.1)
     mini_magick (4.12.0)
     mini_mime (1.1.2)
     mini_portile2 (2.8.1)
@@ -138,6 +146,7 @@ GEM
       timeout
     net-smtp (0.3.3)
       net-protocol
+    netrc (0.11.0)
     nio4r (2.5.8)
     nokogiri (1.13.10)
       mini_portile2 (~> 2.8.0)
@@ -148,6 +157,8 @@ GEM
     parallel (1.22.1)
     parser (3.2.1.0)
       ast (~> 2.4.1)
+    payjp (0.0.10)
+      rest-client (~> 2.0)
     pg (1.4.5)
     pry (0.14.2)
       coderay (~> 1.1)
@@ -197,6 +208,11 @@ GEM
     responders (3.1.0)
       actionpack (>= 5.2)
       railties (>= 5.2)
+    rest-client (2.1.0)
+      http-accept (>= 1.7.0, < 2.0)
+      http-cookie (>= 1.0.2, < 2.0)
+      mime-types (>= 1.16, < 4.0)
+      netrc (~> 0.8)
     rexml (3.2.5)
     rspec-core (3.12.1)
       rspec-support (~> 3.12.0)
@@ -267,6 +283,9 @@ GEM
     turbolinks-source (5.2.0)
     tzinfo (1.2.11)
       thread_safe (~> 0.1)
+    unf (0.1.4)
+      unf_ext
+    unf_ext (0.0.8.2)
     unicode-display_width (2.4.2)
     warden (1.2.9)
       rack (>= 2.0.9)
@@ -307,6 +326,7 @@ DEPENDENCIES
   listen (>= 3.0.5, < 3.2)
   mini_magick
   mysql2 (>= 0.5.3)
+  payjp
   pg
   pry-rails
   puma (~> 3.11)

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 ### Association
 
 - has_many :items
-- has_many :purchases
+- has_many :orders
 
 
 ## items テーブル
@@ -36,10 +36,10 @@
 ### Association
 
 - belongs_to :user
-- has_one :purchase
+- has_one :order
 
 
-## purchases テーブル
+## orders テーブル
 
 | Column | Type       | Options                        |
 | ------ | ---------- | ------------------------------ |
@@ -50,21 +50,21 @@
 
 - belongs_to :user
 - belongs_to :item
-- has_one :order
+- has_one :address
 
 
-## orders テーブル
+## addresses テーブル
 
 | Column        | Type       | Options                        |
 | ------------- | ---------- | ------------------------------ |
 | post_code     | string     | null: false                    |
 | city          | string     | null: false                    |
-| address       | string     | null: false                    |
+| street        | string     | null: false                    |
 | building      | string     |                                |
 | phone_num     | string     | null: false                    |
-| purchase      | references | null: false, foreign_key: true |
+| order         | references | null: false, foreign_key: true |
 | prefecture_id | integer    | null: false                    |
 
 ### Association
 
-- belongs_to :purchase
+- belongs_to :order

--- a/app/assets/stylesheets/orders/index.css
+++ b/app/assets/stylesheets/orders/index.css
@@ -1,0 +1,157 @@
+.transaction-contents {
+  width: 100vw;
+  background-color: #f5f5f5;
+  display: flex;
+  justify-content: center;
+}
+
+.transaction-main {
+  background-color: #FFF;
+  width: 70vw;
+  min-width: 450px;
+  padding: 10vh 10vw;
+}
+
+.transaction-title-text {
+  text-align: center;
+  border-bottom: 2px solid #f5f5f5;
+  font-weight: bold;
+  font-size: 22px;
+}
+
+/* 購入内容の表示 */
+.buy-item-info {
+  height: 150px;
+  border-bottom: 2px solid #f5f5f5;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.buy-item-img {
+  margin-right: 20px;
+  height: 130px;
+  width: 250px;
+  object-fit: contain;
+}
+
+.buy-item-right-content {
+  display: flex;
+  flex-direction: column;
+}
+
+.buy-item-text {
+  font-size: 20px;
+}
+
+.buy-item-price {
+  display: flex;
+  font-weight: bold;
+  align-items: center;
+  margin-top: 10px;
+}
+
+.item-price-text {
+  font-size: 15px;
+  margin-right: 20px;
+}
+
+.item-price-sub-text {
+  font-size: 12px;
+}
+
+/* /購入内容の表示 */
+
+/* 支払額の表示 */
+.item-payment {
+  height: 120px;
+  display: flex;
+  justify-content: space-around;
+  align-items: center;
+  border-bottom: 2px solid #f5f5f5;
+  font-weight: bold;
+}
+
+.item-payment-title {
+  font-size: 20px;
+}
+
+.item-payment-price {
+  font-size: 25px;
+}
+
+/* /支払額の表示 */
+
+/* カード情報の入力 */
+.credit-card-form {
+  border-bottom: 2px solid #f5f5f5;
+  margin-top: 15px;
+  padding-bottom: 30px;
+}
+
+.info-input-haedline {
+  text-align: center;
+  font-weight: bold;
+  font-size: 20px;
+}
+
+.available-card {
+  display: flex;
+  height: 35px;
+}
+
+.card-logo {
+  width: 40px;
+  margin: 5px 5px;
+}
+
+.input-expiration-date-wrap {
+  width: 100%;
+  display: flex;
+  text-align: center;
+  line-height: 55px;
+}
+
+.input-expiration-date {
+  width: 20%;
+  margin-top: 5px;
+  height: 48px;
+  border-radius: 4px;
+  border: 1px solid #ccc;
+  background: #fff;
+  font-size: 16px;
+  resize: none;
+  line-height: 45px;
+  text-align: center;
+}
+
+/* /カード情報の入力 */
+
+/* 配送先の入力 */
+.shipping-address-form {
+  margin-top: 15px;
+}
+
+.form-any {
+  background: #ccc;
+  border-radius: 2px;
+  color: #fff;
+  font-size: 12px;
+  padding: 2px 4px;
+}
+
+.buy-btn {
+  width: 50%;
+  margin: 0 auto;
+  margin-top: 50px;
+}
+
+.buy-red-btn {
+  width: 100%;
+  background: #ea352d;
+  border: 1px solid #ea352d;
+  color: #fff;
+  line-height: 48px;
+  font-size: 14px;
+  cursor: pointer;
+}

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -23,7 +23,7 @@ class ItemsController < ApplicationController
   end
 
   def edit
-    if current_user.id != @item.user_id
+    if current_user.id != @item.user_id || @item.order
       redirect_to root_path
     end
   end

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -1,0 +1,38 @@
+class OrdersController < ApplicationController
+  before_action :authenticate_user!
+
+  def index
+    @item = Item.find(params[:item_id])
+    if current_user.id == @item.user_id || @item.order
+      redirect_to root_path
+    end
+    @order_address = OrderAddress.new
+  end
+
+  def create
+    @order_address = OrderAddress.new(order_params)
+    if @order_address.valid?
+      pay_item
+      @order_address.save
+      redirect_to root_path
+    else
+      @item = Item.find(params[:item_id])
+      render :index
+    end
+  end
+
+  private
+
+  def order_params
+    params.require(:order_address).permit(:post_code, :prefecture_id, :city, :street, :building, :phone_num).merge(user_id: current_user.id, item_id: params[:item_id], token: params[:token])
+  end
+
+  def pay_item
+    Payjp.api_key = ENV["PAYJP_SECRET_KEY"]
+    Payjp::Charge.create(
+      amount: Item.find(params[:item_id]).price,
+      card: order_params[:token],
+      currency: 'jpy'
+    )
+  end
+end

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -1,8 +1,8 @@
 class OrdersController < ApplicationController
   before_action :authenticate_user!
+  before_action :set_item, only: [:index, :create]
 
   def index
-    @item = Item.find(params[:item_id])
     if current_user.id == @item.user_id || @item.order
       redirect_to root_path
     end
@@ -16,7 +16,6 @@ class OrdersController < ApplicationController
       @order_address.save
       redirect_to root_path
     else
-      @item = Item.find(params[:item_id])
       render :index
     end
   end
@@ -25,6 +24,10 @@ class OrdersController < ApplicationController
 
   def order_params
     params.require(:order_address).permit(:post_code, :prefecture_id, :city, :street, :building, :phone_num).merge(user_id: current_user.id, item_id: params[:item_id], token: params[:token])
+  end
+
+  def set_item
+    @item = Item.find(params[:item_id])
   end
 
   def pay_item

--- a/app/helpers/orders_helper.rb
+++ b/app/helpers/orders_helper.rb
@@ -1,0 +1,2 @@
+module OrdersHelper
+end

--- a/app/javascript/card.js
+++ b/app/javascript/card.js
@@ -1,0 +1,32 @@
+const pay = () => {
+  const payjp = Payjp(process.env.PAYJP_PUBLIC_KEY);
+  const elements = payjp.elements();
+  const numberElement = elements.create('cardNumber');
+  const expiryElement = elements.create('cardExpiry');
+  const cvcElement = elements.create('cardCvc');
+
+  numberElement.mount('#number-form');
+  expiryElement.mount('#expiry-form');
+  cvcElement.mount('#cvc-form');
+
+  const submit = document.getElementById("button");
+
+  submit.addEventListener("click", (e) => {
+    e.preventDefault();
+    payjp.createToken(numberElement).then(function (response) {
+      if (response.error) {
+      } else {
+        const token = response.id;
+        const renderDom = document.getElementById("charge-form");
+        const tokenObj = `<input value=${token} name='token' type="hidden">`;
+        renderDom.insertAdjacentHTML("beforeend", tokenObj);
+      }
+      numberElement.clear();
+      expiryElement.clear();
+      cvcElement.clear();
+      document.getElementById("charge-form").submit();
+    });
+  });
+};
+
+window.addEventListener("load", pay);

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -7,6 +7,7 @@ require("@rails/ujs").start()
 require("@rails/activestorage").start()
 require("channels")
 require("../calc_price")
+require("../card")
 
 
 // Uncomment to copy all static images under ../images to the output folder and reference

--- a/app/models/address.rb
+++ b/app/models/address.rb
@@ -1,0 +1,3 @@
+class Address < ApplicationRecord
+  belongs_to :order
+end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -1,6 +1,7 @@
 class Item < ApplicationRecord
   belongs_to :user
   has_one_attached :image
+  has_one :order
 
   validates :image, :name, :description, :price, presence: true
   validates :price, numericality: { only_integer: true, greater_than: 299, less_than: 10_000_000 }, allow_blank: true

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -1,0 +1,5 @@
+class Order < ApplicationRecord
+  belongs_to :user
+  belongs_to :item
+  has_one :address
+end

--- a/app/models/order_address.rb
+++ b/app/models/order_address.rb
@@ -1,0 +1,19 @@
+class OrderAddress
+  include ActiveModel::Model
+  attr_accessor :user_id, :item_id, :token, :post_code, :prefecture_id, :city, :street, :building, :phone_num
+
+  validates :user_id, :item_id, :token, :post_code, presence: true
+
+  validates :post_code, format: { with: /\A[0-9]{3}-[0-9]{4}\z/ }, allow_blank: true
+
+  validates :prefecture_id, numericality: { other_than: 0, message: "can't be blank" }
+
+  validates :city, :street, :phone_num, presence: true
+
+  validates :phone_num, format: { with: /\A[0-9]{10,11}\z/ }, allow_blank: true
+
+  def save
+    order = Order.create(user_id: user_id, item_id: item_id)
+    Address.create(order_id: order.id, post_code: post_code, prefecture_id: prefecture_id, city: city, street: street, building: building, phone_num: phone_num)
+  end
+end

--- a/app/models/order_address.rb
+++ b/app/models/order_address.rb
@@ -2,14 +2,16 @@ class OrderAddress
   include ActiveModel::Model
   attr_accessor :user_id, :item_id, :token, :post_code, :prefecture_id, :city, :street, :building, :phone_num
 
-  validates :user_id, :item_id, :token, :post_code, presence: true
-
+  with_options presence: true do
+    validates :user_id, :item_id, :token, :post_code
+  end
   validates :post_code, format: { with: /\A[0-9]{3}-[0-9]{4}\z/ }, allow_blank: true
 
   validates :prefecture_id, numericality: { other_than: 0, message: "can't be blank" }
 
-  validates :city, :street, :phone_num, presence: true
-
+  with_options presence: true do
+    validates :city, :street, :phone_num
+  end
   validates :phone_num, format: { with: /\A[0-9]{10,11}\z/ }, allow_blank: true
 
   def save

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,6 +5,7 @@ class User < ApplicationRecord
          :recoverable, :rememberable, :validatable
 
   has_many :items
+  has_many :orders
 
   PASSWORD_REGEX = /\A(?=.*?[a-z])(?=.*?[\d])[a-z\d]+\z/i.freeze
   validates_format_of :password, with: PASSWORD_REGEX, allow_blank: true

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -134,11 +134,11 @@
             <div class='item-img-content'>
               <%= image_tag item.image, class: "item-img" %>
 
-              <%# 商品が売れていればsold outを表示しましょう %>
-              <%# <div class='sold-out'>
-                <span>Sold Out!!</span>
-              </div> %>
-              <%# //商品が売れていればsold outを表示しましょう %>
+              <% if item.order %>
+                <div class='sold-out'>
+                  <span>Sold Out!!</span>
+                </div>
+              <% end %>
 
             </div>
             <div class='item-info'>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -8,11 +8,11 @@
     </h2>
     <div class="item-img-content">
       <%= image_tag @item.image, class:"item-box-img" %>
-      <%# 商品が売れている場合は、sold outを表示しましょう %>
-      <%# <div class="sold-out">
-        <span>Sold Out!!</span>
-      </div> %>
-      <%# //商品が売れている場合は、sold outを表示しましょう %>
+      <% if @item.order %>
+        <div class="sold-out">
+          <span>Sold Out!!</span>
+        </div>
+      <% end %>
     </div>
     <div class="item-price-box">
       <span class="item-price">
@@ -23,15 +23,13 @@
       </span>
     </div>
 
-    <% if user_signed_in? %>
+    <% if user_signed_in? && !@item.order %>
       <% if current_user.id == @item.user_id %>
         <%= link_to "商品の編集", edit_item_path(@item.id), method: :get, class: "item-red-btn" %>
         <p class="or-text">or</p>
         <%= link_to "削除", item_path(@item.id), method: :delete, class:"item-destroy" %>
       <% else %>
-        <%# 商品が売れていない場合はこちらを表示しましょう %>
-        <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
-        <%# //商品が売れていない場合はこちらを表示しましょう %>
+        <%= link_to "購入画面に進む", item_orders_path(@item.id) ,class:"item-red-btn"%>
       <% end %>
     <% end %>
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -5,8 +5,8 @@
   <title>Furima</title>
   <%= csrf_meta_tags %>
   <%= csp_meta_tag %>
-  <script type="text/javascript" src="https://js.pay.jp/v1/"></script>
-  <%= stylesheet_link_tag 'application', media: 'all'%>
+  <script type="text/javascript" src="https://js.pay.jp/v2/pay.js"></script>
+  <%= stylesheet_link_tag 'application', media: 'all' %>
   <%= javascript_pack_tag 'application' %>
 </head>
 

--- a/app/views/orders/index.html.erb
+++ b/app/views/orders/index.html.erb
@@ -1,0 +1,129 @@
+<%= render "shared/second-header"%>
+
+<div class='transaction-contents'>
+  <div class='transaction-main'>
+    <h1 class='transaction-title-text'>
+      購入内容の確認
+    </h1>
+    <%# 購入内容の表示 %>
+    <div class='buy-item-info'>
+      <%= image_tag @item.image, class: 'buy-item-img' %>
+      <div class='buy-item-right-content'>
+        <h2 class='buy-item-text'>
+          <%= @item.name %>
+        </h2>
+        <div class='buy-item-price'>
+          <p class='item-price-text'>¥<%= @item.price %></p>
+          <p class='item-price-sub-text'><%= @item.ship_fee.name %></p>
+        </div>
+      </div>
+    </div>
+    <%# /購入内容の表示 %>
+
+    <%# 支払額の表示 %>
+    <div class='item-payment'>
+      <h1 class='item-payment-title'>
+        支払金額
+      </h1>
+      <p class='item-payment-price'>
+        ¥<%= @item.price %>
+      </p>
+    </div>
+    <%# /支払額の表示 %>
+
+    <%= form_with model: @order_address, url: item_orders_path, id: 'charge-form', class: 'transaction-form-wrap', local: true do |f| %>
+
+      <%= render 'shared/error_messages', model: f.object %>
+
+      <%# カード情報の入力 %>
+      <div class='credit-card-form'>
+        <h1 class='info-input-haedline'>
+          クレジットカード情報入力
+        </h1>
+        <div class="form-group">
+          <div class='form-text-wrap'>
+            <label class="form-text">カード情報</label>
+            <span class="indispensable">必須</span>
+          </div>
+          <div id="number-form" class="input-default"></div>
+          <div class='available-card'>
+            <%= image_tag 'card-visa.gif', class: 'card-logo'%>
+            <%= image_tag 'card-mastercard.gif', class: 'card-logo'%>
+            <%= image_tag 'card-jcb.gif', class: 'card-logo'%>
+            <%= image_tag 'card-amex.gif', class: 'card-logo'%>
+          </div>
+        </div>
+        <div class="form-group">
+          <div class='form-text-wrap'>
+            <label class="form-text">有効期限</label>
+            <span class="indispensable">必須</span>
+          </div>
+          <div id="expiry-form" class="input-default"></div>
+        </div>
+        <div class="form-group">
+          <div class='form-text-wrap'>
+            <label class="form-text">セキュリティコード</label>
+            <span class="indispensable">必須</span>
+          </div>
+          <div id="cvc-form" class="input-default"></div>
+        </div>
+      </div>
+      <%# /カード情報の入力 %>
+      
+      <%# 配送先の入力 %>
+      <div class='shipping-address-form'>
+        <h1 class='info-input-haedline'>
+          配送先入力
+        </h1>
+        <div class="form-group">
+          <div class='form-text-wrap'>
+            <label class="form-text">郵便番号</label>
+            <span class="indispensable">必須</span>
+          </div>
+          <%= f.text_field :post_code, class:"input-default", id:"postal-code", placeholder:"例）123-4567", maxlength:"8" %>
+        </div>
+        <div class="form-group">
+          <div class='form-text-wrap'>
+            <label class="form-text">都道府県</label>
+            <span class="indispensable">必須</span>
+          </div>
+          <%= f.collection_select(:prefecture_id, Prefecture.all, :id, :name, {}, {class:"select-box", id:"prefecture"}) %>
+        </div>
+        <div class="form-group">
+          <div class='form-text-wrap'>
+            <label class="form-text">市区町村</label>
+            <span class="indispensable">必須</span>
+          </div>
+          <%= f.text_field :city, class:"input-default", id:"city", placeholder:"例）横浜市緑区"%>
+        </div>
+        <div class="form-group">
+          <div class='form-text-wrap'>
+            <label class="form-text">番地</label>
+            <span class="indispensable">必須</span>
+          </div>
+          <%= f.text_field :street, class:"input-default", id:"addresses", placeholder:"例）青山1-1-1"%>
+        </div>
+        <div class="form-group">
+          <div class='form-text-wrap'>
+            <label class="form-text">建物名</label>
+            <span class="form-any">任意</span>
+          </div>
+          <%= f.text_field :building, class:"input-default", id:"building", placeholder:"例）柳ビル103"%>
+        </div>
+        <div class="form-group">
+          <div class='form-text-wrap'>
+            <label class="form-text">電話番号</label>
+            <span class="indispensable">必須</span>
+          </div>
+          <%= f.text_field :phone_num, class:"input-default", id:"phone-number", placeholder:"例）09012345678",maxlength:"11"%>
+        </div>
+      </div>
+      <%# /配送先の入力 %>
+      <div class='buy-btn'>
+        <%= f.submit "購入" ,class:"buy-red-btn", id:"button" %>
+      </div>
+    <% end %>
+  </div>
+</div>
+
+<%= render "shared/second-footer"%>

--- a/config/initializers/webpacker.rb
+++ b/config/initializers/webpacker.rb
@@ -1,0 +1,1 @@
+Webpacker::Compiler.env["PAYJP_PUBLIC_KEY"] = ENV["PAYJP_PUBLIC_KEY"]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,7 @@
 Rails.application.routes.draw do
   devise_for :users
   root to: "items#index"
-  resources :items, only: [:new, :create, :show, :edit, :update, :destroy]
+  resources :items, only: [:new, :create, :show, :edit, :update, :destroy] do
+    resources :orders, only: [:index, :create]
+  end
 end

--- a/db/migrate/20230307122933_create_orders.rb
+++ b/db/migrate/20230307122933_create_orders.rb
@@ -1,0 +1,9 @@
+class CreateOrders < ActiveRecord::Migration[6.0]
+  def change
+    create_table :orders do |t|
+      t.references :user, null: false, foreign_key: true
+      t.references :item, null: false, foreign_key: true
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20230307123022_create_addresses.rb
+++ b/db/migrate/20230307123022_create_addresses.rb
@@ -1,0 +1,14 @@
+class CreateAddresses < ActiveRecord::Migration[6.0]
+  def change
+    create_table :addresses do |t|
+      t.string     :post_code,     null: false
+      t.integer    :prefecture_id, null: false
+      t.string     :city,          null: false
+      t.string     :street,        null: false
+      t.string     :building
+      t.string     :phone_num,     null: false
+      t.references :order,         null: false, foreign_key: true
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_03_02_093515) do
+ActiveRecord::Schema.define(version: 2023_03_07_123022) do
 
   create_table "active_storage_attachments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name", null: false
@@ -33,6 +33,19 @@ ActiveRecord::Schema.define(version: 2023_03_02_093515) do
     t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
   end
 
+  create_table "addresses", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.string "post_code", null: false
+    t.integer "prefecture_id", null: false
+    t.string "city", null: false
+    t.string "street", null: false
+    t.string "building"
+    t.string "phone_num", null: false
+    t.bigint "order_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["order_id"], name: "index_addresses_on_order_id"
+  end
+
   create_table "items", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name", null: false
     t.text "description", null: false
@@ -46,6 +59,15 @@ ActiveRecord::Schema.define(version: 2023_03_02_093515) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["user_id"], name: "index_items_on_user_id"
+  end
+
+  create_table "orders", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "item_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["item_id"], name: "index_orders_on_item_id"
+    t.index ["user_id"], name: "index_orders_on_user_id"
   end
 
   create_table "users", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
@@ -67,5 +89,8 @@ ActiveRecord::Schema.define(version: 2023_03_02_093515) do
   end
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "addresses", "orders"
   add_foreign_key "items", "users"
+  add_foreign_key "orders", "items"
+  add_foreign_key "orders", "users"
 end

--- a/spec/factories/addresses.rb
+++ b/spec/factories/addresses.rb
@@ -1,0 +1,4 @@
+FactoryBot.define do
+  factory :address do
+  end
+end

--- a/spec/factories/order_addresses.rb
+++ b/spec/factories/order_addresses.rb
@@ -1,0 +1,13 @@
+FactoryBot.define do
+  factory :order_address do
+    Faker::Config.locale = :ja
+
+    token { "tok_#{Faker::Alphanumeric.alphanumeric(number: 28)}" }
+    post_code { Faker::Address.postcode }
+    prefecture_id { Faker::Number.between(from: 1, to: 47) }
+    city { Faker::Address.city }
+    street { Faker::Address.street_address }
+    building { Faker::Address.secondary_address }
+    phone_num { "0#{Faker::Number.between(from: 100000000, to: 9999999999)}" }
+  end
+end

--- a/spec/factories/orders.rb
+++ b/spec/factories/orders.rb
@@ -1,0 +1,4 @@
+FactoryBot.define do
+  factory :order do
+  end
+end

--- a/spec/helpers/orders_helper_spec.rb
+++ b/spec/helpers/orders_helper_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+# Specs in this file have access to a helper object that includes
+# the OrdersHelper. For example:
+#
+# describe OrdersHelper do
+#   describe "string concat" do
+#     it "concats two strings with spaces" do
+#       expect(helper.concat_strings("this","that")).to eq("this that")
+#     end
+#   end
+# end
+RSpec.describe OrdersHelper, type: :helper do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/address_spec.rb
+++ b/spec/models/address_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Address, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/order_address_spec.rb
+++ b/spec/models/order_address_spec.rb
@@ -1,0 +1,155 @@
+require 'rails_helper'
+
+RSpec.describe OrderAddress, type: :model do
+  before do
+    user = FactoryBot.create(:user)
+    item = FactoryBot.create(:item)
+    @order_address = FactoryBot.build(:order_address, user_id: user.id, item_id: item.id)
+    sleep 0.1 #処理が早すぎると同じテストコードでも失敗することがあるので、処理をあえて遅くすることで安定して成功させている。(記述者補足)
+  end
+
+  describe '商品購入' do
+    context '商品を購入できる場合' do
+      it '6項目を適切に入力する: :token, :post_code, :prefecture_id, :city, :street, :phone_num' do
+        expect(@order_address).to be_valid
+      end
+      it 'building は空でも保存できる' do
+        @order_address.building = ''
+        expect(@order_address).to be_valid
+      end
+    end
+
+    context '商品を購入できない場合' do
+      it 'token が空では保存できない' do
+        @order_address.token = nil
+        @order_address.valid?
+        expect(@order_address.errors.full_messages).to include("Token can't be blank")
+      end
+
+      it 'post_code が空では保存できない' do
+        @order_address.post_code = ''
+        @order_address.valid?
+        expect(@order_address.errors.full_messages).to include("Post code can't be blank")
+      end
+      it 'post_code が数字と「-」1個を含めて7桁以下(e.g.123-456)では保存できない' do
+        @order_address.post_code = "#{Faker::Number.number(digits: 3)}-#{Faker::Number.between(from: 0, to: 999)}"
+        @order_address.valid?
+        expect(@order_address.errors.full_messages).to include("Post code is invalid")
+      end
+      it 'post_code が数字と「-」1個を含めて9桁以上(e.g.123-45678)では保存できない' do
+        @order_address.post_code = "#{Faker::Number.number(digits: 3)}-#{Faker::Number.number(digits: 5)}"
+        @order_address.valid?
+        expect(@order_address.errors.full_messages).to include("Post code is invalid")
+      end
+      it 'post_code は「-」の位置が半角数字3桁目より前(e.g.12-34567)だと保存できない' do
+        @order_address.post_code = "#{Faker::Number.number(digits: 2)}-#{Faker::Number.number(digits: 5)}"
+        @order_address.valid?
+        expect(@order_address.errors.full_messages).to include("Post code is invalid")
+      end
+      it 'post_code は「-」の位置が半角数字4桁目より後(e.g.1234-567)だと保存できない' do
+        @order_address.post_code = "#{Faker::Number.number(digits: 4)}-#{Faker::Number.number(digits: 3)}"
+        @order_address.valid?
+        expect(@order_address.errors.full_messages).to include("Post code is invalid")
+      end
+      it 'post_code が英字を含むと保存できない' do
+        @order_address.post_code = "#{Faker::Alphanumeric.alphanumeric(number: 3, min_numeric: 2, min_alpha: 1)}-#{Faker::Number.number(digits: 4)}"
+        @order_address.valid?
+        expect(@order_address.errors.full_messages).to include("Post code is invalid")
+      end
+      it 'post_code が全角数字を含むと保存できない' do
+        @order_address.post_code = "#{Faker::Number.number(digits: 3)}-#{Faker::Number.number(digits: 3)}４"
+        @order_address.valid?
+        expect(@order_address.errors.full_messages).to include("Post code is invalid")
+      end
+      it 'post_code がひらがなを含むと保存できない' do
+        @order_address.post_code = "#{Faker::Number.number(digits: 3)}-#{Faker::Number.number(digits: 3)}し"
+        @order_address.valid?
+        expect(@order_address.errors.full_messages).to include("Post code is invalid")
+      end
+      it 'post_code がカタカナを含むと保存できない' do
+        @order_address.post_code = "#{Faker::Number.number(digits: 3)}-#{Faker::Number.number(digits: 3)}シ"
+        @order_address.valid?
+        expect(@order_address.errors.full_messages).to include("Post code is invalid")
+      end
+      it 'post_code が漢字を含むと保存できない' do
+        @order_address.post_code = "#{Faker::Number.number(digits: 3)}-#{Faker::Number.number(digits: 3)}四"
+        @order_address.valid?
+        expect(@order_address.errors.full_messages).to include("Post code is invalid")
+      end
+
+      it 'prefecture のメニュー選択が初期値「---」では保存できない' do
+        @order_address.prefecture_id = 0
+        @order_address.valid?
+        expect(@order_address.errors.full_messages).to include("Prefecture can't be blank")
+      end
+
+      it 'city が空では保存できない' do
+        @order_address.city = ''
+        @order_address.valid?
+        expect(@order_address.errors.full_messages).to include("City can't be blank")
+      end
+      it 'street が空では保存できない' do
+        @order_address.street = ''
+        @order_address.valid?
+        expect(@order_address.errors.full_messages).to include("Street can't be blank")
+      end
+
+      it 'phone_num が空では保存できない' do
+        @order_address.phone_num = ''
+        @order_address.valid?
+        expect(@order_address.errors.full_messages).to include("Phone num can't be blank")
+      end
+      it 'phone_num が数字9桁以下では保存できない' do
+        @order_address.phone_num = Faker::Number.number(digits: 9)
+        @order_address.valid?
+        expect(@order_address.errors.full_messages).to include("Phone num is invalid")
+      end
+      it 'phone_num が数字12桁以上では保存できない' do
+        @order_address.phone_num = Faker::Number.number(digits: 12)
+        @order_address.valid?
+        expect(@order_address.errors.full_messages).to include("Phone num is invalid")
+      end
+      it 'phone_num が「-」を含むと保存できない' do
+        @order_address.phone_num = "#{Faker::Number.number(digits: 3)}-#{Faker::Number.number(digits: 7)}"
+        @order_address.valid?
+        expect(@order_address.errors.full_messages).to include("Phone num is invalid")
+      end
+      it 'phone_num が英字を含むと保存できない' do
+        @order_address.phone_num = Faker::Alphanumeric.alphanumeric(number: 11, min_numeric: 10, min_alpha: 1)
+        @order_address.valid?
+        expect(@order_address.errors.full_messages).to include("Phone num is invalid")
+      end
+      it 'phone_num が全角数字を含むと保存できない' do
+        @order_address.phone_num = "#{Faker::Number.number(digits: 10)}５"
+        @order_address.valid?
+        expect(@order_address.errors.full_messages).to include("Phone num is invalid")
+      end
+      it 'phone_num がひらがなを含むと保存できない' do
+        @order_address.phone_num = "#{Faker::Number.number(digits: 10)}ご"
+        @order_address.valid?
+        expect(@order_address.errors.full_messages).to include("Phone num is invalid")
+      end
+      it 'phone_num がカタカナを含むと保存できない' do
+        @order_address.phone_num = "#{Faker::Number.number(digits: 10)}ゴ"
+        @order_address.valid?
+        expect(@order_address.errors.full_messages).to include("Phone num is invalid")
+      end
+      it 'phone_num が漢字を含むと保存できない' do
+        @order_address.phone_num = "#{Faker::Number.number(digits: 10)}五"
+        @order_address.valid?
+        expect(@order_address.errors.full_messages).to include("Phone num is invalid")
+      end
+
+      it 'user が紐付いていないと保存できない' do
+        @order_address.user_id = nil
+        @order_address.valid?
+        expect(@order_address.errors.full_messages).to include("User can't be blank")
+      end
+      it 'item が紐付いていないと保存できない' do
+        @order_address.item_id = nil
+        @order_address.valid?
+        expect(@order_address.errors.full_messages).to include("Item can't be blank")
+      end
+    end
+  end
+end

--- a/spec/models/order_spec.rb
+++ b/spec/models/order_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Order, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/requests/orders_request_spec.rb
+++ b/spec/requests/orders_request_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe "Orders", type: :request do
+
+end


### PR DESCRIPTION
# What
商品をクレジットカード決済で購入する機能の、実装から単体テストまで行う。

Formオブジェクトを用いて、購入情報の登録機能を実装する。
秘密鍵などは、値の見える状態でGitHubにpushしない。環境変数化してからcommitする。

### Gyazo URL ###
①必要な情報を適切に入力して「購入」ボタンを押すと、商品の購入ができる動画
①売却済みの商品は、画像上に「sold out」の文字が表示される動画（商品一覧機能実装時に未実装であった場合）
https://gyazo.com/931f4c09447d3639fed5770c153a3d94

②入力に問題がある状態で「購入」ボタンが押された場合、情報は受け入れられず、購入ページでエラーメッセージが表示される動画
https://gyazo.com/48dc11136ada1a8fbd62ab98d2ed7254

③ログイン状態の場合でも、URLを直接入力して自身が出品していない売却済み商品の商品購入ページへ遷移しようとすると、トップページに遷移する動画
https://gyazo.com/0fdc08ea8e6822530bade004405ccf44

④ログイン状態の場合でも、URLを直接入力して自身が出品した商品の商品購入ページに遷移しようとすると、商品の販売状況に関わらずトップページに遷移する動画
https://gyazo.com/a34e045829f8e6b082b874509f0c5e07

⑤ログアウト状態の場合は、URLを直接入力して商品購入ページに遷移しようとすると、商品の販売状況に関わらずログインページに遷移する動画
https://gyazo.com/56ce9b22dcdeecf85301e382363c524a

⑥売却済みの商品は、画像上に「sold out」の文字が表示される動画（商品詳細機能実装時に未実装であった場合）
⑥ログイン状態の場合でも、売却済みの商品には、「商品の編集」「削除」「購入画面に進む」ボタンが表示されない動画（商品詳細機能実装時に未実装であった場合）
https://gyazo.com/01f63d2c63cca8176984c6d4c0a4785d

⑦ログイン状態の場合でも、URLを直接入力して自身が出品した売却済み商品の商品情報編集ページへ遷移しようとすると、トップページに遷移する動画（商品情報編集機能実装時に未実装であった場合）
https://gyazo.com/83d23cf607dd78a5b2f7bcc34479f03f

⑧モデルの単体テスト結果の画像
https://gyazo.com/5d4d2757e8229e3c1d505c291a1ac7b5

# Why
商品購入機能を実装するため。

購入履歴(orders)と配送先情報(addresses)、一度に複数のテーブルへ情報を保存するため。
鍵情報を含んだコードをGitHub上で公開してしまうと、不正請求等の被害に合うリスクが高まるため。